### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -53,12 +53,34 @@
       {
         "url": "https://login.teamviewer.com/oauth2/authorize",
         "methods": ["GET"],
-        "timeout": 10
+        "timeout": 10,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          },
+          "global_access_token": {
+            "body": ["refresh_token"]
+          }
+        }
       },
       {
         "url": "https://webapi.teamviewer.com/api/v1/.*",
         "methods": ["GET", "POST", "PUT"],
-        "timeout": 10
+        "timeout": 10,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          },
+          "global_access_token": {
+            "body": ["refresh_token"]
+          }
+        }
       }
     ]
   }

--- a/manifest.json
+++ b/manifest.json
@@ -52,7 +52,7 @@
     "whitelist": [
       {
         "url": "https://login.teamviewer.com/oauth2/authorize",
-        "methods": ["GET"],
+        "methods": ["GET", "POST"],
         "timeout": 10,
         "settingsInjection": {
           "client_id": {

--- a/src/services/teamviewer/constants.ts
+++ b/src/services/teamviewer/constants.ts
@@ -5,4 +5,4 @@ export const placeholders = {
     GLOBAL_REFRESH_TOKEN: `__global_access_token.json("[refreshToken]")__`,
     ACCESS_TOKEN: "[[oauth/global/access_token]]",
     REFRESH_TOKEN: "[[oauth/global/refresh_token]]",
-};
+} as const;


### PR DESCRIPTION
This pull request introduces updates to the TeamViewer integration, focusing on improved configuration and type safety. The main changes are enhancements to how sensitive credentials are injected into requests, and a minor TypeScript improvement for constants.

**TeamViewer integration improvements:**

* Added a `settingsInjection` configuration for both the OAuth authorization and API endpoints in `manifest.json`, allowing `client_id`, `client_secret`, and `global_access_token` to be injected into the request body from settings.

**Code quality and type safety:**

* Updated the `placeholders` object in `src/services/teamviewer/constants.ts` to use `as const`, ensuring stricter type safety for the exported constants.

## Summary by Sourcery

Improve TeamViewer integration by enabling credential injection via settingsInjection in the app proxy manifest and strengthen type safety of placeholder constants

New Features:
- Add settingsInjection configuration to manifest.json for TeamViewer OAuth and API endpoints to inject client_id, client_secret, and global_access_token into request bodies

Enhancements:
- Apply 'as const' to the placeholders object in TeamViewer constants for stricter type safety